### PR TITLE
Enhance ServiceMonitor with additionalLabels

### DIFF
--- a/helm3/pvc-exporter/templates/pvc-exporter-servicemonitor.yaml
+++ b/helm3/pvc-exporter/templates/pvc-exporter-servicemonitor.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app: {{ $fullName }}
     release: prome
+    {{- if .Values.serviceMonitor.additionalLabels }}
+      {{- toYaml .Values.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
   name: {{ $fullName }}
   namespace: {{.Release.Namespace}}
 spec:

--- a/helm3/pvc-exporter/values.yaml
+++ b/helm3/pvc-exporter/values.yaml
@@ -81,3 +81,4 @@ PvcExporter:
 serviceMonitor:
   enabled: true
   annotations: {}
+  additionalLabels: {}


### PR DESCRIPTION
## Objective
Enhanced the ServiceMonitor template to support `additionalLabels`, allowing for more flexible and detailed monitoring configurations.

## Details
- **Problem**: Previously, the ServiceMonitor template did not support the addition of custom labels, limiting the ability to attach relevant metadata for certain monitoring setups.
- **Solution**: Implemented `additionalLabels` functionality within the ServiceMonitor template. Users can now specify custom labels in the `values.yaml` file, which are then dynamically integrated into the ServiceMonitor manifest.
- **Benefits**: This enhancement allows for more detailed and flexible monitoring configurations. Users can leverage these labels to categorize, filter, and manage their monitoring resources more effectively, fitting a wide array of operational environments and requirements.

## How to Test
1. Update the `values.yaml` file with the desired `additionalLabels`.
2. Deploy the Helm chart.
3. Verify that the generated ServiceMonitor manifest includes the specified labels.
